### PR TITLE
Refactor tests to use dataclass models

### DIFF
--- a/models/customer.py
+++ b/models/customer.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+@dataclass
+class Customer:
+    name: str
+    address: str
+    email: str
+
+@dataclass
+class Order:
+    product_id: int
+    quantity: int
+    price: float
+
+@dataclass
+class Payment:
+    order_id: int
+    amount: float

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -1,0 +1,28 @@
+import pytest
+from models.customer import Customer
+
+@pytest.fixture
+def client():
+    from requests import Session
+    return Session()
+
+def test_create_customer(client):
+    customer = Customer(name='John Doe', address='123 Elm Street', email='john.doe@example.com')
+    response = client.post('http://localhost:8000/customers', json=customer.__dict__)
+    assert response.status_code == 201
+    assert response.json()['name'] == 'John Doe'
+
+def test_get_customer(client):
+    response = client.get('http://localhost:8000/customers/1')
+    assert response.status_code == 200
+    assert response.json()['id'] == 1
+
+def test_update_customer(client):
+    customer = Customer(name='Jane Doe', address='456 Oak Street', email='jane.doe@example.com')
+    response = client.put('http://localhost:8000/customers/1', json=customer.__dict__)
+    assert response.status_code == 200
+    assert response.json()['name'] == 'Jane Doe'
+
+def test_delete_customer(client):
+    response = client.delete('http://localhost:8000/customers/1')
+    assert response.status_code == 204


### PR DESCRIPTION
This PR refactors the test classes to use dataclass models for request payloads. It includes the following changes:

- Added `Customer`, `Order`, and `Payment` dataclass models in `models/customer.py`.
- Refactored `tests/test_customers.py` to use `Customer` dataclass for request payloads.

You can extend the same pattern to other test files and models as needed.