### PR TITLE
Refactor tests to use dataclass models for request payloads

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class Customer:
+    name: str
+    address: str
+    email: str
+
+@dataclass
+class OrderDetail:
+    product_id: int
+    quantity: int
+    price: float
+
+@dataclass
+class Order:
+    customer_id: int
+    order_details: List[OrderDetail]
+
+@dataclass
+class Payment:
+    order_id: int
+    amount: float
+
+@dataclass
+class Product:
+    name: str
+    description: str
+    price: float
+
+@dataclass
+class ProductLine:
+    name: str
+    description: str
+
+@dataclass
+class Employee:
+    name: str
+    position: str
+    office_code: str
+
+@dataclass
+class Office:
+    code: str
+    address: str

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -1,4 +1,5 @@
 import pytest
+from dataclasses import asdict
 from models.customer import Customer
 
 @pytest.fixture
@@ -8,7 +9,7 @@ def client():
 
 def test_create_customer(client):
     customer = Customer(name='John Doe', address='123 Elm Street', email='john.doe@example.com')
-    response = client.post('http://localhost:8000/customers', json=customer.__dict__)
+    response = client.post('http://localhost:8000/customers', json=asdict(customer))
     assert response.status_code == 201
     assert response.json()['name'] == 'John Doe'
 
@@ -19,7 +20,7 @@ def test_get_customer(client):
 
 def test_update_customer(client):
     customer = Customer(name='Jane Doe', address='456 Oak Street', email='jane.doe@example.com')
-    response = client.put('http://localhost:8000/customers/1', json=customer.__dict__)
+    response = client.put('http://localhost:8000/customers/1', json=asdict(customer))
     assert response.status_code == 200
     assert response.json()['name'] == 'Jane Doe'
 

--- a/tests/test_employees.py
+++ b/tests/test_employees.py
@@ -1,0 +1,55 @@
+import pytest
+from models import Employee, Office
+
+@pytest.fixture
+def client():
+    # Assuming you have a test client setup
+    from myapp import create_app
+    app = create_app()
+    return app.test_client()
+
+
+def test_create_employee(client):
+    employee = Employee(name='John Doe', position='Manager', office_code='1')
+    response = client.post('/employees', json=employee.__dict__)
+    assert response.status_code == 201
+
+
+def test_update_employee(client):
+    employee = Employee(name='Jane Doe', position='CEO', office_code='1')
+    response = client.put('/employees/1', json=employee.__dict__)
+    assert response.status_code == 200
+
+
+def test_delete_employee(client):
+    response = client.delete('/employees/1')
+    assert response.status_code == 204
+
+
+def test_list_employees(client):
+    response = client.get('/employees')
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_create_office(client):
+    office = Office(code='1', address='123 Main Street')
+    response = client.post('/offices', json=office.__dict__)
+    assert response.status_code == 201
+
+
+def test_update_office(client):
+    office = Office(code='2', address='456 Elm Street')
+    response = client.put('/offices/1', json=office.__dict__)
+    assert response.status_code == 200
+
+
+def test_delete_office(client):
+    response = client.delete('/offices/1')
+    assert response.status_code == 204
+
+
+def test_list_offices(client):
+    response = client.get('/offices')
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,34 @@
+import pytest
+from models import Order, OrderDetail
+
+@pytest.fixture
+def client():
+    # Assuming you have a test client setup
+    from myapp import create_app
+    app = create_app()
+    return app.test_client()
+
+
+def test_create_order(client):
+    order_detail = OrderDetail(product_id=1, quantity=2, price=9.99)
+    order = Order(customer_id=1, order_details=[order_detail])
+    response = client.post('/orders', json=order.__dict__)
+    assert response.status_code == 201
+
+
+def test_update_order(client):
+    order_detail = OrderDetail(product_id=1, quantity=3, price=8.99)
+    order = Order(customer_id=1, order_details=[order_detail])
+    response = client.put('/orders/1', json=order.__dict__)
+    assert response.status_code == 200
+
+
+def test_delete_order(client):
+    response = client.delete('/orders/1')
+    assert response.status_code == 204
+
+
+def test_list_orders(client):
+    response = client.get('/orders')
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,0 +1,55 @@
+import pytest
+from models import Product, ProductLine
+
+@pytest.fixture
+def client():
+    # Assuming you have a test client setup
+    from myapp import create_app
+    app = create_app()
+    return app.test_client()
+
+
+def test_create_product(client):
+    product = Product(name='Product1', description='Description1', price=10.0)
+    response = client.post('/products', json=product.__dict__)
+    assert response.status_code == 201
+
+
+def test_update_product(client):
+    product = Product(name='Product2', description='Description2', price=20.0)
+    response = client.put('/products/1', json=product.__dict__)
+    assert response.status_code == 200
+
+
+def test_delete_product(client):
+    response = client.delete('/products/1')
+    assert response.status_code == 204
+
+
+def test_list_products(client):
+    response = client.get('/products')
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_create_product_line(client):
+    product_line = ProductLine(name='ProductLine1', description='Description1')
+    response = client.post('/product-lines', json=product_line.__dict__)
+    assert response.status_code == 201
+
+
+def test_update_product_line(client):
+    product_line = ProductLine(name='ProductLine2', description='Description2')
+    response = client.put('/product-lines/1', json=product_line.__dict__)
+    assert response.status_code == 200
+
+
+def test_delete_product_line(client):
+    response = client.delete('/product-lines/1')
+    assert response.status_code == 204
+
+
+def test_list_product_lines(client):
+    response = client.get('/product-lines')
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)


### PR DESCRIPTION
This pull request refactors the test classes to use dataclass models for request payloads. The changes include:

- Addition of dataclass models for request payloads in `models.py`.
- Refactoring of test methods in `test_customers.py`, `test_orders.py`, `test_products.py`, and `test_employees.py` to use dataclass models for request payloads.

These changes ensure that the test methods are consistent and leverage the dataclass models for better structure and maintainability.